### PR TITLE
"Fixed" Path.Update

### DIFF
--- a/flow/flow/Path.cs
+++ b/flow/flow/Path.cs
@@ -31,7 +31,9 @@ namespace flow
 
         public void Update()
         {
-            var current = PathList.First;
+			foreach (var cell in PathList)
+				cell.PipeDirection.Clear();
+			var current = PathList.First;
             for (int i = 0, size = PathList.Count; i < size - 1; i++)
             {
                 var next = current.Next;


### PR DESCRIPTION
I think I was able to fix a rare bug that would occur when connecting cells where a cell would "remember" the wrong direction it was connected from when approaching the final initial cell or other situations I couldn't find, the fix was simple, just resetting cell's "memory" about the directions and rechecking, and since the board is small and computers are fast, it doesn't affect the performance